### PR TITLE
Default width button

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -76,8 +76,50 @@ export default class EditorWidthSlider extends Plugin {
 		const sliderValueText = document.createElement('span');
 		sliderValueText.textContent = slider.value;
 		sliderValueText.classList.add('editor-width-slider-value');
-		sliderValueText.style.marginLeft = '5px';
 
+		// Add the CSS properties to the span element
+		sliderValueText.style.color = 'white';
+		sliderValueText.style.padding = '8px 5px';
+		sliderValueText.style.display = 'inline';
+		sliderValueText.style.borderRadius = '18%';
+		sliderValueText.style.border = '0';
+		sliderValueText.style.margin = '0px 10px';
+		sliderValueText.style.background = 'var(--interactive-accent)';
+		sliderValueText.style.fontSize = '13px';
+		sliderValueText.style.lineHeight = '50%';
+		sliderValueText.style.width = 'auto';
+		sliderValueText.style.height = 'auto';
+		sliderValueText.style.boxSizing = 'content-box';
+
+		// Add a hover effect to change the background color to red
+		sliderValueText.style.transition = 'background 0.3s'; // Add smooth transition
+		sliderValueText.style.cursor = 'pointer'; // Change cursor on hover
+		sliderValueText.addEventListener('mouseenter', function() {
+			sliderValueText.style.background = 'red';
+		});
+		sliderValueText.addEventListener('mouseleave', function() {
+			sliderValueText.style.background = 'var(--interactive-accent)';
+		});
+
+		// color: white;
+		// padding: 9px 5px;
+		// display: inline;
+		// border-radius: 18%;
+		// font-family: "Arial";
+		// border: 0;
+		// margin: 0px 10px;
+		// background: var(--interactive-accent);
+		// font-size: 15px;
+		// line-height: 50%;
+		// width: auto;
+		// height: auto;
+		// box-sizing: content-box;
+
+		// Add a click event listener to the slider value text
+		sliderValueText.addEventListener('click', () => {
+			console.log("test");
+			this.resetEditorWidth()
+		});
 
 		// Create the status bar item
 		const statusBarItemEl = this.addStatusBarItem();
@@ -92,9 +134,10 @@ export default class EditorWidthSlider extends Plugin {
 	}
 
 	resetEditorWidth() {
-		const value = 0;
 		// const widthInPixels = 400 + value * 10;
-		this.settings.sliderPercentage = value.toString();
+		this.settings.sliderPercentage = this.settings.sliderPercentageDefault;
+		const slider = document.getElementById('editor-width-slider')
+		if (slider) slider.value = this.settings.sliderPercentageDefault;
 
 		this.saveSettings();
 		this.updateEditorStyle();

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -11,6 +11,7 @@ import { EditorWidthSliderSettings } from 'src/types/settings';
 // the default value of the thing you want to store 
 export const DEFAULT_SETTINGS: EditorWidthSliderSettings = {
 	sliderPercentage: '20',
+	sliderPercentageDefault: '20',
 	sliderWidth: '150'
 }
 // ---------------------------- Storing Information ----------------------------
@@ -36,6 +37,18 @@ export class EditorWidthSliderSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.sliderWidth)
 				.onChange(async (value) => {
 					this.plugin.settings.sliderWidth = value;
+					this.plugin.updateSliderStyle();
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Slider Default Percentage')
+			.setDesc('What do you want the default percentage of the slider to be?')
+			.addText(text => text
+				.setPlaceholder('Slider width in px')
+				.setValue(this.plugin.settings.sliderPercentageDefault)
+				.onChange(async (value) => {
+					this.plugin.settings.sliderPercentageDefault = value;
 					this.plugin.updateSliderStyle();
 					await this.plugin.saveSettings();
 				}));

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,5 +1,6 @@
 // This plugin will store a single string
 export interface EditorWidthSliderSettings {
 	sliderPercentage: string;
+	sliderPercentageDefault: string;
 	sliderWidth: string;
 }


### PR DESCRIPTION
**Pull Request:** Feature - Reset Slider to Default Percentage

**Changes:**

- Added a feature that allows users to reset the slider to a default percentage value.
- Added a configuration setting to specify the default percentage value.

**Description:**

This pull request introduces a new feature to the Obsidian Line Width Slider Plugin, enabling users to reset the slider to a default percentage value with a single click. To configure the default percentage value, users can now specify it in the plugin settings.

**How to Use:**

1. Click on the number next to the slider, which displays the current percentage value.
2. The slider will reset to the configured default percentage value specified in the settings.

This feature enhances user convenience by providing a quick way to revert to a preferred default editor width setting, especially after adjusting the slider for a specific note.

**Configuration:**

In the plugin settings, you can set the default percentage value that the slider will reset to. This allows you to personalize your default editor width to match your preferred working environment.

**Note**
files that have their width setup in the YAML frontmatter wil reset to the value specified in YAML.

