### PR TITLE
Support Minimal theme line width

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -165,6 +165,7 @@ export default class EditorWidthSlider extends Plugin {
 
 		styleElement.innerText = `
 			body {
+   				--line-width: calc(700px + 10 * ${this.settings.sliderPercentage}px) !important;
 			  	--file-line-width: calc(700px + 10 * ${this.settings.sliderPercentage}px) !important;
 			}
 		`;
@@ -182,6 +183,7 @@ export default class EditorWidthSlider extends Plugin {
 
 		styleElement.innerText = `
 			body {
+   				--line-width: calc(100px + ${editorWidth}vw) !important;
 			  	--file-line-width: calc(100px + ${editorWidth}vw) !important;
 			}
 		`;


### PR DESCRIPTION
Currently, the plugin adjusts the `--file-line-width` SASS variable. It seems that the Minimal theme relies on the `--line-width` variable, instead.

This PR introduces two new lines which, in addition to the existing `--file-line-width` SASS variable, adjust the `--line-width` variable. 

I've tested this on my local Obsidian instance and it seems to work.